### PR TITLE
fix: expose `requiresMainQueueSetup` in RARoutePickerContext

### DIFF
--- a/ios/ReactAirplay/Modules/RARoutePickerContext.swift
+++ b/ios/ReactAirplay/Modules/RARoutePickerContext.swift
@@ -3,6 +3,7 @@ import React
 
 @objc(RARoutePickerContext)
 class RARoutePickerContext: NSObject {
+  @objc 
   static func requiresMainQueueSetup() -> Bool {
     return true
   }


### PR DESCRIPTION
Recent versions of React Native raise a new warning during app initialisation process: 

`
Module RARoutePickerContext requires main queue setup since it overrides init but doesn't implement requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
`

Exposing `requiresMainQueueSetup` in [RARoutePickerContext](https://github.com/tien/react-airplay/blob/main/ios/ReactAirplay/Modules/RARoutePickerContext.swift#L6) to Objective-C seems to be fixing this.

Fixes #113 