### PR TITLE
Link AVKit framework

### DIFF
--- a/.changeset/quick-rivers-link.md
+++ b/.changeset/quick-rivers-link.md
@@ -1,0 +1,5 @@
+---
+"react-airplay": patch
+---
+
+Linked the AVKit framework in the podspec to fix `_OBJC_CLASS_$_AVRoutePickerView` link errors in apps that don't otherwise pull in AVKit.

--- a/ReactAirplay.podspec
+++ b/ReactAirplay.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files = "ios/ReactAirplay/**/*.{h,m,mm}"
   s.private_header_files = "ios/ReactAirplay/**/*.h"
+  s.frameworks = "AVKit"
 
   install_modules_dependencies(s)
 end


### PR DESCRIPTION
## Summary
- Declare AVKit in the podspec so CocoaPods links the framework required by AVRoutePickerView.

## Root cause
The iOS implementation imports AVKit and uses AVRoutePickerView, but the podspec does not declare AVKit as a linked framework. Apps that do not receive AVKit from another dependency can fail at link time with `_OBJC_CLASS_$_AVRoutePickerView`.

## Validation
- `ruby -c ReactAirplay.podspec`
- `git diff --check`