### PR TITLE
ci: switch npm publishing from token to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -25,4 +26,3 @@ jobs:
           title: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "format": "prettier --write \"**/*.{js,ts,tsx,json,md}\" && clang-format -i ios/ReactAirplay/**/*.{h,mm}",
     "format:check": "prettier --check \"**/*.{js,ts,tsx,json,md}\" && clang-format --dry-run -Werror ios/ReactAirplay/**/*.{h,mm}",
-    "publish:packages": "yarn build && yarn workspaces foreach -Apt --no-private npm publish --access public --tolerate-republish && yarn changeset tag"
+    "publish:packages": "yarn build && yarn changeset publish"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
## What

Switch npm publishing from a long-lived `NPM_TOKEN` to [GitHub OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers/).

- **`.github/workflows/publishing.yml`**: grant the publish job `id-token: write` (lets npm exchange a short-lived OIDC credential) and drop `YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`. `GITHUB_TOKEN` stays — changesets/action still needs it for the version PR and releases.
- **`package.json`** (`publish:packages`): publish via `yarn changeset publish` instead of `yarn workspaces foreach … npm publish … && yarn changeset tag`.

## Why

Trusted publishing removes long-lived registry tokens from CI and adds automatic provenance attestations.

We deliberately **don't** use `yarn npm publish` for this: Yarn Berry's OIDC support is recent (Oct 2025) and unreliable in practice (`No authentication configured for request` — [yarnpkg/berry#6952](https://github.com/yarnpkg/berry/issues/6952)). `changeset publish` shells out to the **npm CLI**, which handles the OIDC token exchange natively.

The swap preserves existing behavior:
- **Idempotent** — `changeset publish` skips versions already on the registry, replacing `--tolerate-republish` (matters because changesets/action runs the publish command on every changeset-free push to `main`).
- **Tagging/releases** — it emits the `New tag: react-airplay@x.y.z` lines that `changesets/action` parses to push tags and cut GitHub releases, so the separate `changeset tag` step is no longer needed.
- **Access/private filtering** — already handled by `.changeset/config.json` (`access: public`, `privatePackages: false`).
- **Provenance** — auto-generated (public repo + public package), no flag required.

Requirements (npm ≥ 11.5.1, Node ≥ 22.14.0) are met by the Volta-pinned Node 24.14.0. The package is unscoped, so the scoped-package OIDC bug ([npm/cli#8976](https://github.com/npm/cli/issues/8976)) does not apply.

## ⚠️ Required one-time setup before merging helps

Publishing will fail until a trusted publisher is registered on npm. On **npmjs.com → `react-airplay` → Settings → Trusted Publisher → GitHub Actions**:

| Field | Value |
|---|---|
| Organization or user | `tien` |
| Repository | `react-airplay` |
| Workflow filename | `publishing.yml` |
| Environment | *(leave blank)* |

After a successful OIDC publish, delete the now-unused `NPM_TOKEN` repo secret, and optionally set the npm package to "Require two-factor authentication and disallow tokens".

🤖 Generated with [Claude Code](https://claude.com/claude-code)